### PR TITLE
status message fix compatible

### DIFF
--- a/Test/expired.ts
+++ b/Test/expired.ts
@@ -23,6 +23,6 @@ addCommand({
 		const token = connection && cardfunc.Authorization.Creatable.is(creatable) && await Authorization.create(connection, creatable, true)
 		return gracely.client.malformedContent.is(token) &&
 			token.content.property == "card.pan" &&
-			token.content.description == "Card expired"
+			token.content.description.startsWith("Card expired")
 	}
 })


### PR DESCRIPTION
Compatible with inconsistently spelt "Card expired" clearhaus status message and also compatible with the change to a more consistently spelt "Card expired." (all other status messages ends with "." )